### PR TITLE
#151991931 Integrate Coveralls with read me badge

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-ci
+repo_token: WroN7CxBs6FZisRPMzOAfEChkeaw9I29H

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ package-lock.json
 dist/
 .coverrun
 .env
+.coverdata
+.nyc_output
+coverage
+reports
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ email: false
 script:
   - npm test
 
+after_script:
+  - 'npm run coveralls'
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/andela/mont-blanc-cfh.svg?branch=staging)](https://travis-ci.org/andela/mont-blanc-cfh)
 
+[![Coverage Status](https://coveralls.io/repos/github/andela/mont-blanc-cfh/badge.svg?branch=staging)](https://coveralls.io/github/andela/mont-blanc-cfh?branch=staging)
 
 Cards for Humanity - [http://cfh.io](http://cfh.io)
 ===========

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "npm": "3.10.10"
   },
   "scripts": {
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "bower": "node node_modules/gulp-cli/bin/gulp bower",
     "start": "npm run bower && node node_modules/gulp-cli/bin/gulp",
-    "test": "node node_modules/gulp-cli/bin/gulp test"
+    "test": "nyc --reporter=html --reporter=text node node_modules/gulp-cli/bin/gulp test && npm run coveralls"
   },
   "dependencies": {
     "async": "~0.2.9",
@@ -55,6 +56,9 @@
     "eslint": "^4.9.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.7.0",
+    "coveralls": "^3.0.0",
+    "mocha-lcov-reporter": "^1.3.0",
+    "nyc": "^11.2.1",
     "gulp": "^3.9.1",
     "gulp-babel": "^7.0.0",
     "gulp-bower": "0.0.13",


### PR DESCRIPTION
#### What does this PR do?
It integrates Coveralls with readMe badge
#### Description of Task to be completed?
**Integrate coveralls with readme badge by doing the following:**
* log in to coveralls with Github account.
* Synchronize coveralls with mont-blanch-cfc repo
* Create .coveralls.yml file in local repository 
* Add service name (Travis-ci) and repo-token to the file
* push to Github
* Copy coverage report markdown from coveralls
* push to Github
* Add markdown to readme file as readme badge
#### How should this be manually tested?
* Log into coveralls with Github account
* Get admin access to mont-blanch-cfc repo if need be 
* Sync Github account to Coveralls
* Click mont-blanch-cfc repo link on Coveralls
#### Any background context you want to provide?
none for now.
#### What are the relevant pivotal tracker stories?
#151991931
#### Screenshots
![image](https://user-images.githubusercontent.com/30419014/31718086-750bf7ac-b406-11e7-8134-9a27f32f8492.png)

#### Questions:
none for now