### PR TITLE
#151991938 Re-design users authentication screen

### DIFF
--- a/app/views/includes/head.jade
+++ b/app/views/includes/head.jade
@@ -30,6 +30,6 @@ head
   link(rel='stylesheet', href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css")
   link(rel='stylesheet', href="https://fonts.googleapis.com/css?family=Quicksand|Comfortaa|Righteous|Hammersmith+One")
   link(rel='stylesheet', href='/css/style.css')
-
+  link(rel='stylesheet', href='/css/auth.css')
   //if lt IE 9
     script(src='http://html5shim.googlecode.com/svn/trunk/html5.js')

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -3,23 +3,23 @@ export default [{
     name: 'Cards for Humanity - Development'
   },
   facebook: {
-    clientID: 'APP_ID',
-    clientSecret: 'APP_SECRET',
-    callbackURL: 'http://cardsforhumanity.com:3000/auth/facebook/callback'
+    clientID: process.env.facebookID,
+    clientSecret: process.env.facebookSecret,
+    callbackURL: process.env.callback
   },
   twitter: {
-    clientID: 'CONSUMER_KEY',
-    clientSecret: 'CONSUMER_SECRET',
-    callbackURL: 'http://cardsforhumanity.com:3000/auth/twitter/callback'
+    clientID: process.env.twitterID,
+    clientSecret: process.env.twitterSecret,
+    callbackURL: process.env.callback
   },
   github: {
-    clientID: 'APP_ID',
-    clientSecret: 'APP_SECRET',
-    callbackURL: 'http://cardsforhumanity.com:3000/auth/github/callback'
+    clientID: process.env.githubID,
+    clientSecret: process.env.githubSecret,
+    callbackURL: process.env.callback
   },
   google: {
-    clientID: 'APP_ID',
-    clientSecret: 'APP_SECRET',
-    callbackURL: 'http://cardsforhumanity.com:3000/auth/google/callback'
+    clientID: process.env.googleID,
+    clientSecret: process.env.googleSecret,
+    callbackURL: process.env.callback
   }
 }];

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,25 +1,25 @@
 export default [{
   app: {
-    name: 'Cards for Humanity'
+    name: 'Cards for Humanity - Development'
   },
   facebook: {
-    clientID: 'APP_ID',
-    clientSecret: 'APP_SECRET',
-    callbackURL: 'http://cfh.io/auth/facebook/callback'
+    clientID: process.env.facebookID,
+    clientSecret: process.env.facebookSecret,
+    callbackURL: process.env.callback
   },
   twitter: {
-    clientID: 'CONSUMER_KEY',
-    clientSecret: 'CONSUMER_SECRET',
-    callbackURL: 'http://cfh.io/auth/twitter/callback'
+    clientID: process.env.twitterID,
+    clientSecret: process.env.twitterSecret,
+    callbackURL: process.env.callback
   },
   github: {
-    clientID: 'APP_ID',
-    clientSecret: 'APP_SECRET',
-    callbackURL: 'http://cfh.io/auth/github/callback'
+    clientID: process.env.githubID,
+    clientSecret: process.env.githubSecret,
+    callbackURL: process.env.callback
   },
   google: {
-    clientID: 'APP_ID',
-    clientSecret: 'APP_SECRET',
-    callbackURL: 'http://cfh.io/auth/google/callback'
+    clientID: process.env.googleID,
+    clientSecret: process.env.googleSecret,
+    callbackURL: process.env.callback
   }
 }];

--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -1,0 +1,137 @@
+.navbar-scroll {
+	background-color: #43bf06 !important;
+    padding: 0px;
+    height:70px;
+}
+
+.row {
+    padding: 0;
+    margin: 0;
+}
+
+
+div.well {
+    height: 250px;
+} 
+      
+.Fixed-Center {
+    margin: auto;
+    position: absolute;
+    top: 0; left: 0; bottom: 0; right: 0;
+}
+
+.Fixed-Center.is-Responsive {
+    width: 50%; 
+    max-height: 400px;
+    min-width: 400px;
+    max-width: 500px;
+    padding: 40px;
+}
+
+.first-section {
+    background-image: url('../img/newimage4.png');
+    background-size: cover;
+    min-height:100%;
+    background-position: center;
+    display: flex;
+    flex-direction: row;
+    background-attachment: fixed;
+}
+
+.content {
+    text-align: center;
+}
+
+body, html {
+    padding: 0;
+    margin: 0;
+    height: 100%;
+}
+
+.row {
+    padding: 0;
+    margin: 0;
+}
+
+body form {
+    background-color: white;
+    padding: 19px;
+    width: 100%;
+}
+
+.fa-github{
+    color:#fff;
+    background-color:#444;
+    border-color:rgba(0,0,0,0.2)
+}
+
+/* .fa-google-plus{
+color:#fff;
+background-color:#dd4b39;
+border-color:rgba(0,0,0,0.2)
+} */
+
+.btn-social{
+    position:relative;
+    padding-left:44px;
+    text-align:left;
+    white-space:nowrap;
+    overflow:hidden;
+    text-overflow:ellipsis
+}
+
+.social-box{
+    margin: 0 auto;
+    padding: 38px;
+    border-bottom:1px #ccc solid;
+    }
+.social-box a{
+    font-weight:bold;
+    font-size:10px;
+    padding:8px;
+}
+.social-box a i{
+    font-weight:bold;
+    font-size:20px;
+}
+.mg-btm{
+    margin-bottom:20px;
+}
+
+.github {
+    background: #1F0404;
+}
+
+.footer-section {
+    background-color:black;
+}
+
+.footer-section p {
+    color: white;
+    padding-top: 30px;
+    padding-bottom: 30px;
+    font-family: 'HammersmithOne';
+}
+
+.footer-section p a {
+    color: #43bf06;
+    font-family: 'HammersmithOne';
+}
+
+.footer-section .github{
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-content: center;
+    align-items: center;
+} 
+
+.footer-section .github .twitter-follow-button .btn{
+    height: 50px;
+}
+@media (max-width: 400px) {
+.footer-section .github{
+    margin-top: 0px;
+    float: left;
+} 
+}

--- a/public/views/signin.html
+++ b/public/views/signin.html
@@ -1,71 +1,103 @@
-<div id="main-bod" ng-controller="IndexController">
-  <!-- Fixed Logo & Menu Bar Start -->
-  <div id="top-part">
-    <div class="wpb-top-bar">
-      <div class="mod-contain" id="navver">
-        <div class="row">
-          <!-- Logo -->
-          <div class="wpb-logo-container">
-            <div id="landing-logo"> 
-              <span id="first-word">Cards</span>
-              <span id="second-word"> for</span> 
-              <span id="third-word">Humanity</span> 
-            </div> 
-            <div class="col-md-9 wpb-menu-container">
-              <ul class="wpb-main-menu">
-                <li><a href="/">Home</a></li>
-              </ul>
-            </div>
-          </div>      
-        </div>
-      </div>
-    </div>
-  </div>
-<!-- Fixed Logo & Menu Bar End -->
+<div landing id="main-bod" ng-controller="IndexController">
+  <body data-spy="scroll" data-target=".navbar" data-offset="50">
 
-<!-- Landing Start -->
-<div class="wpb-teaser parallax-background" id="homer">
-  <div class="background-opacity"></div> 
-  <div class="modified-container">
-    <div class="row" id="main-text"> 
-    <!-- Teaser Text Start -->
-    <div id="landing-logo">
-      <h2 id="slogan">Sign in with:</h2>
-      <div id="login-buttons">
-        <a href="/auth/facebook"><img class="login-item" src="/img/icons/facebook.png"></a>
-        <a href="/auth/github"><img class="login-item" src="/img/icons/github.png"></a>
-        <a href="/auth/twitter"><img class="login-item" src="/img/icons/twitter.png"></a>
-        <a href="/auth/google"><img class="login-item" src="/img/icons/google.png"></a>
-      </div>
-      <p id="create">Or log in below:</p>
 
-      <div class="sign-body">
-        <div class="more-sign">
-          <div class="sign-error" ng-show="showError() === 'invalid'">
-            Please check your username/password and try again.
+    <!-- Navigation -->
+    <nav class="navbar navbar-default navbar-fixed-top">
+        <div class="container">
+          <a class="navbar-brand" href="#"><img src="./img/logo.png" alt="logo"></a>
+          <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="navbarResponsive">
+            <ul class="navbar-nav navbar-right">
+              <li class="nav-item active">
+                <a class="nav-link" href="/">Home
+                </a>
+              </li>
+              <li class="nav-item active">
+                <a class="nav-link" href="/#!/#about">About
+                </a>
+              </li>
+              <li class="nav-item active">
+                <a class="nav-link" data-scroll href="/#!/#charity">Charity
+                </a>
+              </li>
+  
+              <li class="nav-item active" ng-show="showOptions">
+                  <a class="nav-link" href="signup">Sign up
+                  </a>
+               </li>
+            </ul>
           </div>
-          <form class="signup form-horizontal" ng-submit="logIn()">
-            <div class="control-group">
-              <label for="email" class="control-label"></label>
-              <div class="controls">
-                <input class="input-info" id="email" type="text" name="email" placeholder="Email" ng-model="data.email" required novalidate />
-              </div>
-            </div>
-            <div class="control-group">
-              <label for="password" class="control-label"></label>
-              <div class="controls">
-                <input class="input-info" id="password" type="password" name="password" placeholder="Password" ng-model="data.password" required novalidate />
-              </div>
-            </div>
-            <div class="form-actions top-margin">
-              <button id="sign-up-btn-other" type='submit'>Sign In</button>
-            </div>
-          </form>
         </div>
-      </div>
-    </div>
-    </div>
-    </div>
-  </div>
-</div>
+      </nav>
 
+    <div class="container">
+            <div class="row">
+              <div class="Fixed-Center is-Responsive col-xs-8">
+                <div>
+                  <form class="glyphicon" action="" id="SigninForm" action="/users/session" method="post">
+                    <div class="sign-error" ng-show="showError() === 'invalid'">
+                      
+                    </div>
+                    <div class="social-box">
+                        <div class="row mg-btm">
+                            <div class="col-md-3">
+                                <a href="/auth/facebook" class="btn btn-primary btn-block">
+                                    <i class="fa fa-facebook"></i>
+                                </a>
+                            </div>
+                            <div class="col-md-3">
+                                    <a href="/auth/github" class="btn btn-link btn-block github" >
+                                        <i class="fa fa-github"></i>
+                                    </a>
+                            </div>
+                            <div class="col-md-3">
+                                    <a href="/auth/twitter" class="btn btn-info btn-block" >
+                                        <i class="fa fa-twitter"></i>
+                                    </a>
+                            </div>
+                            <div class="col-md-3">
+                                    <a href="/auth/google" class="btn btn-danger btn-block" >
+                                        <i class="fa fa-google-plus"></i>
+                                    </a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group input-group">
+                      <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
+                      <input class="form-control" id="email" type="text" name='email' placeholder="Email" required novalidate/>          
+                    </div>
+                    <div class="form-group input-group">
+                      <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+                      <input class="form-control" id="password" type="password" name='password' placeholder="Password" required novalidate/>     
+                    </div>
+                    <div class="form-group">
+                      <button type="submit" class="btn btn-success btn-block">Signin</button>
+                    </div>
+                    <div class="form-group text-center">
+                      Don't have an account? <a href="signup">Sign up</a>
+                    </div>
+                  </form>        
+                </div>  
+              </div>    
+            </div>
+        </div>
+
+   <!-- First section content -->
+
+   <div class="container-fluid first-section">
+    <div class="container content">
+
+    </div>
+   </div>
+      
+   <!-- First section content ends here-->
+
+   </div>
+  </body>
+</html>

--- a/public/views/signup.html
+++ b/public/views/signup.html
@@ -1,85 +1,112 @@
-<div id="main-bod" ng-controller="IndexController">
-  <!-- Fixed Logo & Menu Bar Start -->
-  <div id="top-part">
-    <div class="wpb-top-bar">
-      <div class="mod-contain" id="navver">
-        <div class="row">
-          <!-- Logo -->
-          <div class="wpb-logo-container">
-            <div id="landing-logo"> 
-              <span id="first-word">Cards</span>
-              <span id="second-word"> for</span> 
-              <span id="third-word">Humanity</span> 
-            </div> 
-            <div class="col-md-9 wpb-menu-container">
-              <ul class="wpb-main-menu">
-                <li><a href="/">Home</a></li>
-              </ul>
-            </div>
-          </div>      
-        </div>
-      </div>
-    </div>
-  </div>
-<!-- Fixed Logo & Menu Bar End -->
+<div landing id="main-bod" ng-controller="IndexController">
+  <body data-spy="scroll" data-target=".navbar" data-offset="50">
 
-<!-- Landing Start -->
-<div class="wpb-teaser parallax-background" id="homer">
-  <div class="background-opacity"></div> 
-  <div class="modified-container">
-    <div class="row" id="main-text"> 
-    <!-- Teaser Text Start -->
-    <div id="landing-logo">
-      <h2 id="slogan">Sign Up with:</h2>
-      <div id="login-buttons">
-        <a href="/auth/facebook"><img class="login-item" src="/img/icons/facebook.png"></a>
-        <a href="/auth/github"><img class="login-item" src="/img/icons/github.png"></a>
-        <a href="/auth/twitter"><img class="login-item" src="/img/icons/twitter.png"></a>
-        <a href="/auth/google"><img class="login-item" src="/img/icons/google.png"></a>
-      </div>
-      <p id="create">Or create a username/password and select an avatar:</p>
 
-      <div class="sign-body">
-        <div class="more-sign">
-          <div class="sign-error" ng-show="showError() === 'invalid'">
-            Please check your username/password and try again.
+    <!-- Navigation -->
+    <nav class="navbar navbar-default navbar-fixed-top">
+        <div class="container">
+          <a class="navbar-brand" href="#"><img src="./img/logo.png" alt="Logo"></a>
+          <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="navbarResponsive">
+            <ul class="navbar-nav navbar-right">
+              <li class="nav-item active">
+                <a class="nav-link" href="/">Home
+                </a>
+              </li>
+              <li class="nav-item active">
+                <a class="nav-link" href="/#!/#about">About
+                </a>
+              </li>
+              <li class="nav-item active">
+                <a class="nav-link" data-scroll href="/#!/#charity">Charity
+                </a>
+              </li>
+  
+              <li class="nav-item active" ng-show="showOptions">
+                  <a class="nav-link" href="signin">Sign In
+                  </a>
+               </li>
+            </ul>
           </div>
-          <form class="signup form-horizontal" ng-submit="signUp()">
-              <div class="control-group">
-                <label for="name" class="control-label"></label>
-                <div class="controls">
-                  <input class="input-info" id="name" type="text" name="name" ng-model="data.name" placeholder="Full name" required novalidate />
-                </div>
-              </div>
-              <div class="control-group">
-                <label for="email" class="control-label"></label>
-                <div class="controls">
-                  <input class="input-info" id="email" type="email" name="email" ng-model="data.email" placeholder="Email" required novalidate />
-                </div>
-              </div>
-              <div class="control-group">
-                <label for="password" class="control-label"></label>
-                <div class="controls">
-                  <input class="input-info" id="password" type="password" name="password" ng-model="data.password" placeholder="Password" required novalidate />
-                </div>
-              </div>
-              <div id="contain-avatars">
-                <ul ng-controller="IndexController" class="avatar-list">
-                  <li ng-repeat="avatar in avatars" class="avatars ng-scope">
-                    <input name="avatar" type='radio' value="{{$index}}">
-                      <img ng-src="{{avatar}}">
-                    </input>
-                  </li>
-                </ul>
-              </div>
-              <div class="form-actions">
-                <button id="sign-up-btn-other" type='submit'>Sign Up</button>
-              </div>
-            </form>
         </div>
-      </div>
+      </nav>
+
+    <div class="container">
+            <div class="row">
+              <div class="Fixed-Center is-Responsive col-xs-8">
+                <div>
+                  <form class="glyphicon" action="" id="SigninForm" ng-submit="signUp()">
+                      <div class="sign-error" ng-show="showError() === 'invalid'">
+                        
+                      </div>
+                    <div class="social-box">
+                        <div class="row mg-btm">
+                            <div class="col-md-3">
+                                <a href="/auth/facebook" class="btn btn-primary btn-block">
+                                    <i class="fa fa-facebook"></i>
+                                </a>
+                            </div>
+                            <div class="col-md-3">
+                                    <a href="/auth/github" class="btn btn-link btn-block github" >
+                                        <i class="fa fa-github"></i>
+                                    </a>
+                            </div>
+                            <div class="col-md-3">
+                                    <a href="/auth/twitter" class="btn btn-info btn-block" >
+                                        <i class="fa fa-twitter"></i>
+                                    </a>
+                            </div>
+                            <div class="col-md-3">
+                                    <a href="/auth/goggle" class="btn btn-danger btn-block" >
+                                        <i class="fa fa-google-plus"></i>
+                                    </a>
+                            </div>
+                        </div>
+                    </div>
+                        <div class="form-group input-group">
+                            <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+                            <input class="form-control" id="name" type="text" name='name' placeholder="Full name" ng-model="data.name" required novalidate/>     
+                        </div>
+                    <div class="form-group input-group">
+                      <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
+                      <input class="form-control" id="email" type="email" name='email' placeholder="Email" ng-model="data.email" required novalidate/>          
+                    </div>
+                    <div class="form-group input-group">
+                      <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+                      <input class="form-control" id="password" type="password" name='password' placeholder="Password" ng-model="data.password" required novalidate/>     
+                    </div>
+                    <div class="form-group input-group">
+                            <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+                            <input class="form-control" type="password" name='confirmpassword' placeholder="Confirm password" required novalidate/>     
+                    </div>
+                    <div class="form-group">
+                      <button type="submit" class="btn btn-success btn-block">Signup</button>
+                    </div>
+                    <div class="form-group text-center">
+                      Have an account? <a href="signin">Sign in</a>
+                    </div>
+                  </form>        
+                </div>  
+              </div>    
+            </div>
+        </div>
+    
+
+   <!-- First section content -->
+
+   <div class="container-fluid first-section">
+    <div class="container content">
+
     </div>
-    </div>
-    </div>
-  </div>
-</div>
+   </div>
+      
+   <!-- First section content ends here-->
+
+   </div>
+  </body>
+</html>


### PR DESCRIPTION
#### What does this PR do?

Re-design the user authentication screen

#### Description of Task to be completed?

Users should see a redesigned login/signup screen with the option to authenticate via facebook, twitter, github and google.

#### How should this be manually tested?

Start the app
Visit localhost:3001/signin or localhost:3001/signup on browser.

#### Any background context you want to provide?

Authentication via the social icons requires app secret and clientID set in the environment variables

#### What are the relevant pivotal tracker stories?

#151991938

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30489733/32291972-e289f0e8-bf3e-11e7-83f4-5cb7942f1403.png)
![image](https://user-images.githubusercontent.com/30489733/32292001-fa5941ba-bf3e-11e7-86e6-6a40cc6202fe.png)
